### PR TITLE
Natural sorting implementation

### DIFF
--- a/Src/TacentView.cpp
+++ b/Src/TacentView.cpp
@@ -486,13 +486,22 @@ int Viewer::NaturalSort(const char8_t *a, const char8_t *b)
 		}
 		else // mode == NUMBER
 		{
+			char *end; // Represents the end of the number string
+
+			// Get the left number
+			unsigned long aInt = strtoul((char*) a, &end, 10);
+			a = (char8_t*) end;
+
+			// Get the right number
+			unsigned long bInt = strtoul((char*) b, &end, 10);
+			b = (char8_t*) end;
+
 			// if the difference is not equal to zero, we have a comparison result
-			const long diff = static_cast<long>(*a) - static_cast<long>(*b);
+			const long diff = aInt - bInt;
 			if (diff != 0) return diff;
 
 			// otherwise we process the next substring in STRING mode
 			mode = STRING;
-			++a; ++b;
 		}
 	}
 

--- a/Src/TacentView.cpp
+++ b/Src/TacentView.cpp
@@ -487,11 +487,12 @@ int Viewer::NaturalSort(const char8_t *a, const char8_t *b)
 		else // mode == NUMBER
 		{
 			// if the difference is not equal to zero, we have a comparison result
-			const long diff = tAtoi(a) - tAtoi(b);
+			const long diff = static_cast<long>(*a) - static_cast<long>(*b);
 			if (diff != 0) return diff;
 
 			// otherwise we process the next substring in STRING mode
 			mode = STRING;
+			++a; ++b;
 		}
 	}
 

--- a/Src/TacentView.h
+++ b/Src/TacentView.h
@@ -120,6 +120,7 @@ namespace Viewer
 	void SortImages(Config::ProfileData::SortKeyEnum, bool ascending);
 	bool DeleteImageFile(const tString& imgFile, bool tryUseRecycleBin);
 
+	int NaturalSort(const char8_t* a, const char8_t* b);			// Implements a natural sorting algorithm so files withs numbers appear in a pleasing format for humans
 	Config::ProfileData::ZoomModeEnum GetZoomMode();				// Reads the ZoomModePerImage setting to see where to get the zoom mode.
 	void SetZoomMode(Config::ProfileData::ZoomModeEnum);			// Reads the ZoomModePerImage setting to see where to set the zoom mode.
 	float GetZoomPercent();											// Reads the ZoomModePerImage setting to see where to get the zoom percent.


### PR DESCRIPTION
Hello,

I noticed some annoying sorting behaviors that were annoying to me: 
- Files with numbers weren't displayed in proper sequence
  - For example, comic pages were displayed out of order when the numbering wasn't formatted over a consistent number of chars, which would lead to things like: 'Page_(1)', 'Page_(10)', 'Page_(11)', 'Page_(2)', 'Page_(3)'
- Unlike on Windows, uppercase in filenames on Linux are significant, meaning the sorting put the files that started with a capital letter at the start of the list
- Both these issues meant navigating files between the File Explorer and Tacentview was inconsistent

and so I decided to implement a natural sorting rule, which solved both those problems at the same time for all OSs.
I haven't profiled it properly, but I haven't noticed any sort of slowdown, even on a large number of files (the biggest I had was 141, and it was instantaneous).

I only implemented the sorting on the Viewer for now, since it was the part that was bothering me the most, but it might be a good idea to include it in more places, especially in the file explorer (where the filetree is also completely out of order, at least on Linux)